### PR TITLE
fix: 학번 TextField 유효성 길이 관련 rules 수정

### DIFF
--- a/src/pages/LoginRegister/RegisterDetail/RegisterDetail.tsx
+++ b/src/pages/LoginRegister/RegisterDetail/RegisterDetail.tsx
@@ -52,11 +52,11 @@ export const RegisterDetail = () => {
         <TextField
           name="studentId"
           title="학번"
-          description="학번을 입력해주세요... ex) 20, 19"
+          description="학번을 입력해주세요... ex) 20201234"
           control={control}
           rules={{
             required: '학번을 입력하세요.',
-            pattern: { value: /^[0-9]{2}$/, message: '학번은 두 자리 숫자로 입력해주세요.' },
+            pattern: { value: /^[0-9]{8}$/, message: '학번은 8자리 숫자로 입력해주세요.' },
           }}
         />
         <TextField


### PR DESCRIPTION
## 1️⃣ 어떤 작업을 했나요? (Summary)

- resolved #28 

학번을 2글자에서 8글자로 입력하도록 수정하였습니다.

```tsx
        <TextField
          name="studentId"
          title="학번"
          description="학번을 입력해주세요... ex) 20201234"
          control={control}
          rules={{
            required: '학번을 입력하세요.',
            pattern: { value: /^[0-9]{8}$/, message: '학번은 8자리 숫자로 입력해주세요.' },
          }}
        />
```

## 4️⃣ 체크리스트 (Checklist)

- [x] `main` 브랜치의 최신 코드를 `pull` 받았나요?
