### PR TITLE
feat: 로그인/비로그인 별 홈 화면 설정

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,6 +8,7 @@
   </head>
   <body>
     <div id="root"></div>
+    <div id="modal"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -29,7 +29,7 @@ const publicRoutes: RouteObject[] = [
     children: [
       {
         path: '/',
-        element: <Landing />,
+        element: <Home />,
       },
       {
         path: '/landing',
@@ -48,10 +48,6 @@ const publicRoutes: RouteObject[] = [
             element: <RegisterDetail />,
           },
         ],
-      },
-      {
-        path: '/home',
-        element: <Home />,
       },
     ],
   },

--- a/src/components/Modal/Modal.style.ts
+++ b/src/components/Modal/Modal.style.ts
@@ -1,0 +1,45 @@
+import styled from 'styled-components';
+import { getFontStyle } from '@/styles/typo';
+import colors from '@/styles/color';
+
+export const StyledModalBackground = styled.div`
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: rgba(0, 0, 0, 0.6);
+
+  z-index: 1000;
+`;
+
+export const StyledModal = styled.div`
+  display: flex;
+  flex-flow: column;
+  align-items: center;
+
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+
+  background-color: #fff;
+  border-radius: 12px;
+
+  padding: 10px;
+
+  width: 300px;
+  height: fit-content;
+  z-index: 1000;
+`;
+
+export const StyledModalTitle = styled.div`
+  margin-top: 10px;
+  ${getFontStyle('Header5')};
+  color: ${colors.text};
+`;
+
+export const StyledModalContent = styled.div`
+  ${getFontStyle('Caption1_B')};
+  color: ${colors.text};
+`;

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -1,0 +1,28 @@
+import ReactDOM from 'react-dom';
+import { StyledModal, StyledModalBackground } from './Modal.style';
+import { StyledTitlePin, StyledTitlePinContainer } from '@/pages/LoginRegister/LoginRegister.style';
+
+interface ModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  children: React.ReactNode;
+}
+
+export const Modal = ({ isOpen, onClose, children }: ModalProps) => {
+  if (!isOpen) return null;
+
+  const modalRoot = document.getElementById('modal') as HTMLElement;
+
+  return ReactDOM.createPortal(
+    <StyledModalBackground onClick={onClose}>
+      <StyledModal onClick={(e) => e.stopPropagation()}>
+        <StyledTitlePinContainer>
+          <StyledTitlePin $width="LONG" />
+          <StyledTitlePin $width="SHORT" />
+        </StyledTitlePinContainer>
+        {children}
+      </StyledModal>
+    </StyledModalBackground>,
+    modalRoot
+  );
+};

--- a/src/components/Panel/LoginPanel/LoginPanel.tsx
+++ b/src/components/Panel/LoginPanel/LoginPanel.tsx
@@ -38,7 +38,7 @@ export const LoginPanel = () => {
       const response: LoginResponse = await login(data);
       setUser({ email: data.email, password: data.password });
       alert('로그인에 성공했습니다!');
-      navigate('/home');
+      navigate('/');
       sessionStorage.setItem('user', JSON.stringify(response));
     } catch (error: any) {
       setError('email', {

--- a/src/components/Profile/Profile.style.ts
+++ b/src/components/Profile/Profile.style.ts
@@ -2,53 +2,54 @@ import styled from 'styled-components';
 import { getFontStyle } from '@/styles/typo';
 import colors from '@/styles/color';
 
-
 export const ProfileWrapper = styled.div`
-    display: flex;
-    flex-direction: row;
-    align-items: center;
-    padding-right: 18px;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  padding-right: 18px;
 `;
 
 export const UserAvatar = styled.div`
-    position: relative;
-    left: 2rem;
-    background-color: ${colors.profile_background};
-    width: 45px;
-    height: 45px;
-    border-radius: 50%;
+  position: relative;
+  left: 2rem;
+  background-color: ${colors.profile_background};
+  width: 45px;
+  height: 45px;
+  border-radius: 50%;
 
-    display: flex;          
-    justify-content: center;
-    align-items: center;  
+  display: flex;
+  justify-content: center;
+  align-items: center;
 `;
 
 export const UserInfoWrapper = styled.div`
-    background-color: ${colors.profile_background};
-    width: 121px;
-    height: 35px;
-    flex-shrink: 0;
+  background-color: ${colors.profile_background};
+  width: 121px;
+  height: 35px;
+  flex-shrink: 0;
 
-    display: flex;
-    justify-content: center;
-    align-items: center;  
-    border-radius: 20px;
-`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  border-radius: 20px;
+`;
 
 export const NameWrapper = styled.div`
-    background-color: ${colors.profile_text_background};
-    width: 82px;
-    height: 22px;
-    border-radius: 11px;
+  background-color: ${colors.profile_text_background};
+  width: 82px;
+  height: 22px;
+  border-radius: 11px;
 
-    position: relative;
-    left: 10px;
+  position: relative;
+  left: 10px;
+
+  overflow: hidden;
+  text-overflow: ellipsis;
 `;
 
 export const UserName = styled.h1`
-    color: ${colors.profile_text};
-    line-height: 1.8;
-    ${getFontStyle('Caption2_B')}
-    text-align: center;
+  color: ${colors.profile_text};
+  line-height: 1.8;
+  ${getFontStyle('Caption2_B')}
+  text-align: center;
 `;
-

--- a/src/components/Profile/Profile.tsx
+++ b/src/components/Profile/Profile.tsx
@@ -1,23 +1,67 @@
+import { useState } from 'react';
 import {
   ProfileWrapper,
   UserAvatar,
   UserInfoWrapper,
   NameWrapper,
-  UserName
+  UserName,
 } from './Profile.style';
 import AvatarIcon from '@/assets/icons/avatar.svg';
+import { Modal } from '@/components/Modal/Modal';
+import { StyledModalContent, StyledModalTitle } from '@/components/Modal/Modal.style';
+import { Spacing } from '@/components/Spacing/Spacing';
+import { Button } from '@/components/Button/Button';
+import { useNavigate } from 'react-router-dom';
 
-export const Profile = ({ name = '알 수 없음' }) => (  
-  <ProfileWrapper>
-    <UserAvatar>
-      <img src={AvatarIcon} alt="avatar" />
-    </UserAvatar>
-    <UserInfoWrapper>
-       <NameWrapper>
-        <UserName>{name}</UserName>
-      </NameWrapper>
-    </UserInfoWrapper>
-  </ProfileWrapper>
-);
+export type ProfileProps = {
+  name?: string;
+  userName?: string;
+  setUserStorage: React.Dispatch<React.SetStateAction<string | null>>;
+};
 
+export const Profile: React.FC<ProfileProps> = ({
+  name = '알 수 없음',
+  userName = '',
+  setUserStorage,
+}) => {
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const navigate = useNavigate();
 
+  const handleOpenModal = () => setIsModalOpen(true);
+  const handleCloseModal = () => setIsModalOpen(false);
+
+  const handleLogout = () => {
+    sessionStorage.removeItem('user');
+    setUserStorage(null);
+    navigate('/');
+    handleCloseModal();
+  };
+
+  return (
+    <>
+      <ProfileWrapper onClick={handleOpenModal}>
+        <UserAvatar>
+          <img src={AvatarIcon} alt="avatar" />
+        </UserAvatar>
+        <UserInfoWrapper>
+          <NameWrapper>
+            <UserName>{name}</UserName>
+          </NameWrapper>
+        </UserInfoWrapper>
+      </ProfileWrapper>
+
+      <Modal isOpen={isModalOpen} onClose={handleCloseModal}>
+        <StyledModalTitle>내 정보</StyledModalTitle>
+        <Spacing size={16} direction="vertical" />
+        <StyledModalContent>{userName}</StyledModalContent>
+        <Spacing size={8} direction="vertical" />
+        <StyledModalContent>{name}</StyledModalContent>
+        <Spacing size={20} direction="vertical" />
+        <Button size="BIG" text="로그아웃" onClick={handleLogout} />
+        <Spacing size={10} direction="vertical" />
+        <Button size="BIG" text="닫기" onClick={handleCloseModal} />
+        <Spacing size={8} direction="vertical" />
+      </Modal>
+    </>
+  );
+};

--- a/src/types/homeSection.type.ts
+++ b/src/types/homeSection.type.ts
@@ -1,0 +1,6 @@
+import { RankedSchoolData } from './hightSchool-ranking.type';
+
+export interface homeSectionProps {
+  isUser: boolean;
+  rankedSchoolData: RankedSchoolData[];
+}


### PR DESCRIPTION
## 1️⃣ 어떤 작업을 했나요? (Summary)

- resolved #31 

- [x] 로그인/비로그인 별 헤더 설정 및 스타일 수정
    - [x] 로그인 시, 학교 이름이 길 경우 처리
    - [x] 로그인 시, 로그아웃 버튼 추가
    - [x] 비로그인 시, 로고 밑에 로그인 버튼 추가
- [x] 홈화면 라우팅 `/home` => `/` 으로 변경

## 4️⃣ 체크리스트 (Checklist)

- [x] `main` 브랜치의 최신 코드를 `pull` 받았나요?
